### PR TITLE
updates for mongodb 2.0 (mongod 3.0.4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 test:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 		--require should \
-		--harmony-generators \
+		--harmony \
 		--bail
 
 testg:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 		--require should \
-		--harmony-generators \
+		--harmony \
 		--bail \
 		--grep $(grep)
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -56,8 +56,6 @@ var thunk = [
   'close',
   // 'admin', // @TODO // Returns Admin object
   'eval',
-  'collectionNames',
-  // 'dereference', // @TODO
   'logout',
   'authenticate',
   'addUser',
@@ -65,17 +63,12 @@ var thunk = [
   'command',
   'dropCollection',
   'renameCollection',
-  'lastError',
-  'previousErrors',
-  'resetErrorHistory',
   'createIndex',
   'ensureIndex',
-  'cursorInfo',
   'dropIndex',
   'reIndex',
   'indexInformation',
-  'dropDatabase',
-  'stats'
+  'dropDatabase'
 ];
 
 /**
@@ -136,7 +129,7 @@ collection.forEach(function (method) {
  */
 
 var cursor = [
-  'collectionsInfo'
+  'listCollections'
 ];
 
 /**
@@ -148,13 +141,7 @@ cursor.forEach(function (method) {
     var args = [].slice.call(arguments);
     var db = this._db;
 
-    return function (done) {
-      args.push(function (err, cursor) {
-        if (err) return done(err);
-        done(null, new Cursor(cursor));
-      });
-      db[method].apply(db, args);
-    };
+    return new Cursor(db[method].apply(db, args));
   };
 });
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "test": "make test"
   },
   "author": "Thom Seddon",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/thomseddon/co-mongo"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thomseddon/co-mongo"
   },
   "license": "MIT",
   "dependencies": {
-    "mongodb": "~1.3.23"
+    "mongodb": "2.0.49"
   },
   "devDependencies": {
     "mocha": "~1.17.1",

--- a/test/collection.js
+++ b/test/collection.js
@@ -1,6 +1,5 @@
 
 var setup = require('./setup');
-var mongo = require('mongodb');
 var comongo = require('../');
 var co = require('co');
 
@@ -16,8 +15,8 @@ describe('collection', function () {
     it('should insert', function (done) {
       co(function *() {
         var res = yield test.insert({ hello: 'thom' });
-        res[0].should.have.keys(['hello', '_id']);
-        res[0].hello.should.equal('thom');
+        res.ops[0].should.have.keys(['hello', '_id']);
+        res.ops[0].hello.should.equal('thom');
       })(done);
     });
   });
@@ -26,7 +25,7 @@ describe('collection', function () {
     it('should remove', function (done) {
       co(function *() {
         var res = yield test.remove({ hello: 'world' });
-        res.should.equal(1);
+        res.result.ok.should.equal(1);
       })(done);
     });
   });
@@ -44,8 +43,8 @@ describe('collection', function () {
     it('should save', function (done) {
       co(function *() {
         var res = yield test.save({ hello: 'thom' });
-        res.should.have.keys(['hello', '_id']);
-        res.hello.should.equal('thom');
+        res.ops[0].should.have.keys(['hello', '_id']);
+        res.ops[0].hello.should.equal('thom');
       })(done);
     });
   });
@@ -54,9 +53,8 @@ describe('collection', function () {
     it('should update', function (done) {
       co(function *() {
         var res = yield test.update({ hello: 'world' }, { hello: 'thom' });
-        res[0].should.equal(1);
-        res[1].should.have.keys(['updatedExisting', 'n', 'connectionId', 'err',
-          'ok']);
+        res.result.n.should.equal(1);
+        res.result.should.have.keys(['nModified', 'n', 'ok']);
       })(done);
     });
   });
@@ -93,8 +91,8 @@ describe('collection', function () {
       co(function *() {
         var res = yield test.findAndModify({ hello: 'world' }, [['hello', 1]],
           {$set: { hello: 'thom' }});
-        res[0].should.have.keys(['_id', 'hello']);
-        // res[0].hello.should.equal('thom'); // @TODO
+        res.value.should.have.keys(['_id', 'hello']);
+        // res.ops[0].hello.should.equal('thom'); // @TODO
       })(done);
     });
   });
@@ -103,7 +101,7 @@ describe('collection', function () {
     it('should findAndRemove', function (done) {
       co(function *() {
         var res = yield test.findAndRemove({ hello: 'world' }, [['hello', 1]]);
-        res[0].should.have.keys(['_id', 'hello']);
+        res.value.should.have.keys(['_id', 'hello']);
       })(done);
     });
   });
@@ -217,7 +215,7 @@ describe('collection', function () {
     it('should return options', function (done) {
       co(function *() {
         var res = yield test.options();
-        res.should.eql({ create: 'test_collection' });
+        res.should.eql({});
       })(done);
     });
   });

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -1,7 +1,6 @@
 
 var stream = require('stream');
 var setup = require('./setup');
-var mongo = require('mongodb');
 var comongo = require('../');
 var co = require('co');
 
@@ -91,7 +90,7 @@ describe('cursor', function () {
 
   describe('skip', function () {
     it('should return cursor', function () {
-      var res = test.find().skip();
+      var res = test.find().skip(0);
       res.should.be.instanceOf(comongo.Cursor);
     });
   });
@@ -118,10 +117,7 @@ describe('cursor', function () {
     it('should return cursor', function (done) {
       co(function *() {
         var res = yield test.find().explain();
-        res.should.have.keys(['cursor', 'isMultiKey', 'n', 'nscannedObjects',
-          'nscanned', 'nscannedObjectsAllPlans', 'nscannedAllPlans',
-          'scanAndOrder', 'indexOnly', 'nYields', 'nChunkSkips', 'millis',
-          'indexBounds', 'allPlans', 'server']);
+        res.should.have.keys(['queryPlanner', 'executionStats', 'serverInfo']);
       })(done);
     });
   });
@@ -130,7 +126,6 @@ describe('cursor', function () {
     it('should return stream', function () {
       var res = test.find().stream();
       res.should.be.instanceOf(stream.Stream);
-      setup.db = false; // Flag db as closed
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 
-var mongo = require('mongodb');
 var comongo = require('../');
 var co = require('co');
 

--- a/test/mongoclient.js
+++ b/test/mongoclient.js
@@ -1,5 +1,4 @@
 
-var mongo = require('mongodb');
 var comongo = require('../');
 var co = require('co');
 


### PR DESCRIPTION
Can change the target branch if needed, but this'll get things up and running for mongodb 3.x and `mongodb` 2.x driver as 2.0 drivers and 3.0 dbs are incompatible `MongoError: driver is incompatible with this server version`
- add user roles in tests (mongo >= 2.6)
- remove deprecated collection and db prototype methods
- update mongodb dependency to 2.0.49
- update assertions for the respones format of insert / upsert queries
- update assertions for key matching on returned result objects /
  cursors
- remove test examples for deprecated methods
- add removeUser step to setup since user wasn't dropped with database
  during test teardown
